### PR TITLE
fix: change `const server` to `var server`

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ const getToken = exports.getToken = function (params, callback, onChange) {
 function startCallbackServer (callback, nightmare) {
   callback = once(callback)
 
-  const server = http.createServer(function (req, res) {
+  var server = http.createServer(function (req, res) {
     res.writeHead(200)
     res.end()
 


### PR DESCRIPTION
When the old code is run as ES2015 (say, Node 6) the later assignment to `server` results in a `TypeError: Assignment to constant variable.`
