### PR TITLE
Fix "Cannot retrieve token." Updating nightmare to work on Ubuntu. Fix 'timeout exceeded'

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chai": "^2.1.0",
     "mocha": "^2.1.0",
-    "nightmare": "git+https://github.com/h2non/nightmare.git#master"
+    "nightmare": "^2.10.0"
   },
   "keywords": [
     "nightmare",


### PR DESCRIPTION
I deduced the issue for the Timeout exceeded problem running on Ubuntu.

Here is your current module import hierarchy:
youtube-video-api => includes nightmare @ "https://github.com/h2non/nightmare.git"
youtube-video-api => includes nightmare-google-oauth2 @ (your own repository)
nightmare-google-oauth2 => includes nightmare @ "https://github.com/h2non/nightmare.git"

Your repository version of nightmare includes its own version of electron: electron-prebuilt@0.36.12

The version of electron included by this nightmare version is out of date and has issues running headlessly. Referencing this issue: https://github.com/segmentio/nightmare/issues/228

Additionally, the .wait() calls would hang forever, take too long, or not properly return when the selected elements rendered.

I found this out by looking at the output from running my node app this way: 
DEBUG=nightmare:*,electron:* node --harmony app.js

The solution is to update the included nightmare in your package.json to version "^2.10.0" to automatically include electron@1.6.11 where the stalling issues don't happen.

I tested on Ubuntu and Mac that the new versions of nightmare and electron work fine with the upload API.

Your youtube-video-api module includes this nightmare-google-oauth2 module and will also need this change.

As a side note, thanks a lot for making these two modules! They've been really great for my project